### PR TITLE
add GNOME 42 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Todoist",
   "description": "Lists tasks from Todoist task manager",
-  "shell-version": ["3.36.8", "40", "41"],
+  "shell-version": ["3.36.8", "40", "41", "42"],
   "uuid": "todoist@tarelda.github.com",
   "settings-schema": "org.gnome.shell.extensions.todoist"
 }


### PR DESCRIPTION
Hi, thank you very much for this extension. Was able to enable it on GNOME 42.2 after adding the version number to the metadata and it works great so far! 